### PR TITLE
Correct Wii U extensions in es_systems.cfg, reported by Bilu

### DIFF
--- a/apply_updates.bat
+++ b/apply_updates.bat
@@ -30,6 +30,9 @@ robocopy V:\_tools\vman-retrobat-master\RetroBat\emulators\dolphin-emu\ V:\Retro
 rem 3. 2021-08-05 - Corrent snap naming for High Octane - reported by Bilu
 ren "V:\RetroBat\roms\dos\snap\Hi Octane.pc.mp4" "Hi Octane.mp4"
 
+rem Apply XML-based updates using PowerShell
+powershell -ExecutionPolicy Bypass -File V:\_tools\vman-retrobat-master\xml_updates.ps1
+
 echo.
 echo Update Completed. Enjoy! :)
 echo.

--- a/xml_updates.ps1
+++ b/xml_updates.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference= 'silentlycontinue'
+
+############# Put es_systems.cfg changes in this block ###############
+$es_systems_path = 'V:\RetroBat\emulationstation\.emulationstation\es_systems.cfg'
+[xml]$es_systems = Get-Content $es_systems_path ; 
+
+# 5. 2021-09-03 - Correct Wii U extensions in es_systems.cfg, reported by Bilu
+$wiiu = $es_systems.SelectSingleNode("//system[name='wiiu']")
+$wiiu.extension = '.iso .rpx .wud .m3u .ISO .RPX .WUD .M3U .wux .WUX'
+
+$es_systems.save($es_systems_path) 
+######################################################################


### PR DESCRIPTION
Adding a PowerShell script for XML-based updates, already prepared for future use cases.
Current use case is to change Wii U configured extensions based to RetroBat's default.